### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Implemented a basic Express server with a search endpoint for tasks.

### What changed?

- Created a new `server.js` file in the `graphite-demo` directory.
- Set up an Express server listening on port 3000.
- Defined a sample array of tasks with id and description.
- Implemented a GET `/search` endpoint that filters tasks based on a query parameter.

### How to test?

1. Start the server by running `node server.js`.
2. Send a GET request to `http://localhost:3000/search?query=your_search_term`.
3. Verify that the response contains filtered tasks matching the search term.
4. Try different search terms to ensure proper filtering.

### Why make this change?

This change introduces a basic backend structure for task searching functionality, which can be integrated with a frontend application. It provides a foundation for building a more complex task management system with search capabilities.